### PR TITLE
feature : 유저 id 파라미터 바인딩 annotation 생성

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     /* Redis 추가 시작 */
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     /* Redis 추가 끝 */
+
+    /* AOP 추가 시작 */
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    /* AOP 추가 끝 */
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/backend/domain/auth/exception/InvalidAccessTokenException.java
+++ b/backend/src/main/java/com/example/backend/domain/auth/exception/InvalidAccessTokenException.java
@@ -2,9 +2,7 @@ package com.example.backend.domain.auth.exception;
 
 public class InvalidAccessTokenException extends RuntimeException {
 
-    private static final String DEFAULT_MSG = "유효하지 않은 액세스 토큰입니다.";
-
     public InvalidAccessTokenException() {
-        super(DEFAULT_MSG);
+        super("유효하지 않은 요청입니다.");
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/auth/exception/InvalidAuthCodeException.java
+++ b/backend/src/main/java/com/example/backend/domain/auth/exception/InvalidAuthCodeException.java
@@ -2,9 +2,7 @@ package com.example.backend.domain.auth.exception;
 
 public class InvalidAuthCodeException extends RuntimeException {
 
-    private static final String DEFAULT_MSG = "카카오 인가 코드가 유효하지 않습니다.";
-
     public InvalidAuthCodeException() {
-        super(DEFAULT_MSG);
+        super("카카오 인가 코드가 유효하지 않습니다. 관리자에게 문의해주세요.");
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/auth/exception/KakaoTokenRequestException.java
+++ b/backend/src/main/java/com/example/backend/domain/auth/exception/KakaoTokenRequestException.java
@@ -2,9 +2,7 @@ package com.example.backend.domain.auth.exception;
 
 public class KakaoTokenRequestException extends RuntimeException {
 
-    private static final String DEFAULT_MSG = "카카오 서버의 토큰 요청 과정에서 오류가 발생했습니다.";
-
     public KakaoTokenRequestException() {
-        super(DEFAULT_MSG);
+        super("카카오 서버의 토큰 요청 과정에서 오류가 발생했습니다. 관리자에게 문의해주세요.");
     }
 }

--- a/backend/src/main/java/com/example/backend/domain/user/api/UserController.java
+++ b/backend/src/main/java/com/example/backend/domain/user/api/UserController.java
@@ -1,7 +1,12 @@
 package com.example.backend.domain.user.api;
 
 import com.example.backend.domain.user.service.UserService;
+import com.example.backend.domain.user.service.response.UserInfoResponse;
+import com.example.backend.global.annotation.CurrentUserId;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+
+    @GetMapping("/info")
+    public ResponseEntity<UserInfoResponse> getInfo(@CurrentUserId Long userId) {
+        return new ResponseEntity<>(userService.getInfo(userId), HttpStatus.OK);
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/example/backend/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.example.backend.domain.user.service;
 
 import com.example.backend.domain.user.repository.UserRepository;
+import com.example.backend.domain.user.service.response.UserInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,4 +10,11 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+
+    public UserInfoResponse getInfo(Long userId) {
+        return UserInfoResponse.from(
+            userRepository.findById(userId)
+                .orElseThrow()
+        );
+    }
 }

--- a/backend/src/main/java/com/example/backend/domain/user/service/response/UserInfoResponse.java
+++ b/backend/src/main/java/com/example/backend/domain/user/service/response/UserInfoResponse.java
@@ -1,0 +1,10 @@
+package com.example.backend.domain.user.service.response;
+
+import com.example.backend.domain.user.entity.User;
+
+public record UserInfoResponse(Long memberId, String email) {
+
+    public static UserInfoResponse from(User user) {
+        return new UserInfoResponse(user.getMemberId(), user.getEmail());
+    }
+}

--- a/backend/src/main/java/com/example/backend/global/annotation/CurrentUserId.java
+++ b/backend/src/main/java/com/example/backend/global/annotation/CurrentUserId.java
@@ -1,0 +1,12 @@
+package com.example.backend.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+
+}

--- a/backend/src/main/java/com/example/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/com/example/backend/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.example.backend.global.config;
+
+import com.example.backend.global.resolver.CurrentUserIdArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserIdArgumentResolver currentUserIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserIdArgumentResolver);
+    }
+}

--- a/backend/src/main/java/com/example/backend/global/jwt/filter/JwtFilter.java
+++ b/backend/src/main/java/com/example/backend/global/jwt/filter/JwtFilter.java
@@ -50,8 +50,8 @@ public class JwtFilter extends OncePerRequestFilter {
                     return;
                 }
 
-                Authentication authentication = jwtProvider.createAuthentication(accessToken);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                Authentication auth = jwtProvider.createAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(auth);
             }
 
             if (accessTokenValidateResponse == JwtValidateResponse.EXPIRED) {
@@ -65,12 +65,9 @@ public class JwtFilter extends OncePerRequestFilter {
                     response.getWriter().write("{\"message\": \"재로그인이 필요한 요청입니다.\"}");
                     return;
                 }
-
                 String newAccessToken = jwtProvider.issueNewAccessToken(refreshToken.get().getRefreshToken());
-
                 Authentication authentication = jwtProvider.createAuthentication(newAccessToken);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-
                 response.setHeader("Authorization", "Bearer " + newAccessToken);
             }
         }

--- a/backend/src/main/java/com/example/backend/global/resolver/CurrentUserIdArgumentResolver.java
+++ b/backend/src/main/java/com/example/backend/global/resolver/CurrentUserIdArgumentResolver.java
@@ -1,0 +1,30 @@
+package com.example.backend.global.resolver;
+
+import com.example.backend.global.annotation.CurrentUserId;
+import com.example.backend.global.oauth.KakaoUserDetails;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUserId.class)
+            && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        KakaoUserDetails userDetails = (KakaoUserDetails) authentication.getPrincipal();
+        return userDetails.getMemberId();
+    }
+}


### PR DESCRIPTION
1. @CurrentUserID 
- 사용자 정보가 필요한 요청에 대해 시큐리티 컨텍스트에서 userId를 꺼내와 파라미터에 바인딩하는 어노테이션 생성
- 사용방법은 UserController end point 참고
- JwtFilter에서 pass된 요청만 들어오기 때문에 resolver에서 authentication이 null인 경우나, !isAuthenticated인 경우에 대한 예외처리는 하지 않았음. 

추가로 설명하자면, 이건 AOP가 아니라 ArgumentResolver를 사용한 거라서, 단순히 컨트롤러 메서드의 파라미터에 로그인한 사용자 ID를 바인딩해주는 역할만 함
예를 들어 @CurrentUserId 같은 어노테이션이 붙은 Long userId 파라미터에, SecurityContextHolder에서 꺼낸 값을 자동으로 넣어주는 구조임.

지금 내가 쓴건 니가 전에 말한 AOP 방식이랑은 다른 맥락 
니가 말한건 ㅁ밑에처럼 공통 로직 AOP로 한 군데서 모아서 처리하는 걸 말한 거 같은데
@RequireLogin
@GetMapping("/info")
public ResponseEntity<UserInfoResponse> getInfo(@CurrentUserId Long userId) {

이것처럼 @RequireLogin AOP로 로그인 여부를 검사하고 비로그인 상태면 예외를 던지게 하는 거 말한거 맞음 ? 
 
이거 쓴다면 SecurityConfig에서는 /api/** 전체를 permitAll로 열어두고, AOP에서 @RequireLogin 붙은 메서드만 로그인 여부 검사해서 예외 처리하는 방식으로 처리해도 좋을듯 

1. 모든 URI 열어두고, 로그인 여부는 @RequireLogin 같은 AOP 방식으로 처리
2. SecurityConfig에서 인증이 필요한 URI는 명시적으로 막고, 인증이 필요한 메서드에서는 지금처럼 @CurrentUserId 써서 ID 주입받기

쓰다보니 1에다가 추가로 @CurrentUserId쓰는게 맞는 거 같긴하다 merge ㄴㄴ 낼 커밋다시함 