### PR TITLE
[Feature/#17-guava-rate-limiter] RestClient bean 생성 시 read, connect 타임아웃 설정, guava library를 활용한 rate limiter 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     /* AOP 추가 시작 */
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     /* AOP 추가 끝 */
+
+    /* API RateLimiter 추가 시작 */
+    implementation 'com.google.guava:guava:33.4.8-jre'
+    /* API RateLimiter 추가 끝*/
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/backend/domain/auth/service/KakaoLoginService.java
+++ b/backend/src/main/java/com/example/backend/domain/auth/service/KakaoLoginService.java
@@ -34,6 +34,7 @@ public class KakaoLoginService {
     private final LogoutTokenService logoutTokenService;
     private final UserRepository userRepository;
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+    private final RestClient restClient;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String kakaoClientId;
@@ -97,8 +98,6 @@ public class KakaoLoginService {
     }
 
     private String getAccessToken(String code) {
-        RestClient restClient = RestClient.create();
-
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", kakaoClientId);

--- a/backend/src/main/java/com/example/backend/domain/restaurant/client/KakaoSearchApiClient.java
+++ b/backend/src/main/java/com/example/backend/domain/restaurant/client/KakaoSearchApiClient.java
@@ -17,6 +17,8 @@ public class KakaoSearchApiClient {
     private static final String KEYWORD_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/keyword.json";
     private static final String RESTAURANT_GROUP_CODE = "FD6";
 
+    private final RestClient restClient;
+
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String restApiKey;
 
@@ -28,12 +30,9 @@ public class KakaoSearchApiClient {
                     .build()
                     .toUriString();
 
-            RestClient restClient = RestClient.builder()
-                    .defaultHeader("Authorization", "KakaoAK " + restApiKey)
-                    .build();
-
             KakaoPlacesSearchResponse response = restClient.get()
                     .uri(uri)
+                    .header("Authorization", "KakaoAK " + restApiKey)
                     .retrieve()
                     .body(KakaoPlacesSearchResponse.class);
 

--- a/backend/src/main/java/com/example/backend/global/config/RestClientConfig.java
+++ b/backend/src/main/java/com/example/backend/global/config/RestClientConfig.java
@@ -1,0 +1,26 @@
+package com.example.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.builder()
+                .requestFactory(clientHttpRequestFactory())
+                .build();
+    }
+
+    @Bean
+    public ClientHttpRequestFactory clientHttpRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(2000);
+        factory.setReadTimeout(2000);
+        return factory;
+    }
+}

--- a/backend/src/main/java/com/example/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/com/example/backend/global/config/WebConfig.java
@@ -1,10 +1,13 @@
 package com.example.backend.global.config;
 
+import com.example.backend.global.interceptor.RateLimiterInterceptor;
 import com.example.backend.global.resolver.CurrentUserIdArgumentResolver;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @RequiredArgsConstructor
@@ -12,9 +15,16 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final CurrentUserIdArgumentResolver currentUserIdArgumentResolver;
+    private final RateLimiterInterceptor rateLimiterInterceptor;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(currentUserIdArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimiterInterceptor)
+                .addPathPatterns("/api/**");
     }
 }

--- a/backend/src/main/java/com/example/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/com/example/backend/global/config/WebConfig.java
@@ -25,6 +25,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(rateLimiterInterceptor)
-                .addPathPatterns("/api/**");
+                .addPathPatterns("/api/restaurants/search");
     }
 }

--- a/backend/src/main/java/com/example/backend/global/interceptor/RateLimiterInterceptor.java
+++ b/backend/src/main/java/com/example/backend/global/interceptor/RateLimiterInterceptor.java
@@ -1,5 +1,6 @@
 package com.example.backend.global.interceptor;
 
+import com.example.backend.global.util.IpUtil;
 import com.google.common.util.concurrent.RateLimiter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,7 +34,7 @@ public class RateLimiterInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String ip = request.getRemoteAddr();
+        String ip = IpUtil.getClientIp(request);
         long now = System.currentTimeMillis();
 
         if (!isRequestAllowed(ip)) {

--- a/backend/src/main/java/com/example/backend/global/interceptor/RateLimiterInterceptor.java
+++ b/backend/src/main/java/com/example/backend/global/interceptor/RateLimiterInterceptor.java
@@ -1,0 +1,64 @@
+package com.example.backend.global.interceptor;
+
+import com.google.common.util.concurrent.RateLimiter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings("UnstableApiUsage")
+@Slf4j
+@Component
+public class RateLimiterInterceptor implements HandlerInterceptor {
+
+    private static final double REQUESTS_PER_SECOND = 5.0;
+    private static final long LOG_INTERVAL = TimeUnit.MINUTES.toMillis(1);
+
+    private final ConcurrentHashMap<String, RateLimiter> rateLimiters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Long> lastLoggedTime = new ConcurrentHashMap<>();
+
+    @Value("${rate.limit.enabled:false}")
+    private boolean rateLimitEnabled;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if(!rateLimitEnabled) {
+            return true;
+        }
+
+        String ip = request.getRemoteAddr();
+        long now = System.currentTimeMillis();
+
+        if (!isRequestAllowed(ip)) {
+            if (isLogIntervalElapsed(ip, now)) log.warn("Rate limit exceeded. ip: {}", ip);
+            response.sendError(HttpStatus.TOO_MANY_REQUESTS.value(), "Too many requests");
+            return false;
+        }
+
+        if (isLogIntervalElapsed(ip, now)) log.info("Rate limit passed. ip: {}", ip);
+        return true;
+    }
+
+    private boolean isRequestAllowed(String ip) {
+        RateLimiter rateLimiter = rateLimiters.computeIfAbsent(ip, k -> RateLimiter.create(REQUESTS_PER_SECOND));
+        return rateLimiter.tryAcquire();
+    }
+
+    private boolean isLogIntervalElapsed(String ip, long now) {
+        Long last = lastLoggedTime.get(ip);
+
+        if (last == null || now - last > LOG_INTERVAL) {
+            lastLoggedTime.put(ip, now);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/backend/src/main/java/com/example/backend/global/util/IpUtil.java
+++ b/backend/src/main/java/com/example/backend/global/util/IpUtil.java
@@ -1,0 +1,33 @@
+package com.example.backend.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IpUtil {
+
+    public static String getClientIp(HttpServletRequest request) {
+        final String[] CLIENT_IP_HEADER_NAMES = {
+                "X-Forwarded-For",
+                "Proxy-Client-IP",
+                "WL-Proxy-Client-IP",
+                "HTTP_CLIENT_IP",
+                "HTTP_X_FORWARDED_FOR"
+        };
+
+        for (String header : CLIENT_IP_HEADER_NAMES) {
+            String ip = request.getHeader(header);
+            if (ip != null && !ip.isEmpty() && !"unknown".equalsIgnoreCase(ip)) {
+                log.info("client ip found in header {}: {}", header, ip);
+                return ip;
+            }
+        }
+
+        String ip = request.getRemoteAddr();
+        log.info("client ip resolved from request.getRemoteAddr(): {}", ip);
+        return ip;
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -27,6 +27,10 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     defer-datasource-initialization: true
 
-  logging:
-    level:
-      root: INFO
+logging:
+  level:
+    root: debug
+
+rate:
+  limit:
+    enabled: false

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -30,3 +30,7 @@ spring:
   logging:
     level:
       root: WARN
+
+rate:
+  limit:
+    enabled: true


### PR DESCRIPTION
### RestClient 모듈을 통한 API 요청시, 응답 지연을 막기 위한 Timeout 설정 추가

* read: 2s (2000ms) (응답 읽기)
* connect: 2s(2000ms) (TCP 연결 시간)

### Guava Library를 활용한 Rate Limiter 기능 추가

* RateLimiter: 초당 api 호출 횟수를 제한하도록 돕는 클래스
* Guava Library에서 제공하는 메서드 목록

Modifier and Type | Method | Description
-- | -- | --
static RateLimiter | create​(double permitsPerSecond) | 입력받은 초당 허용량을 가진 RateLimiter 를 생성
double | acquire() | 1회 허가 요청 후 요청이 승인될 때까지 대기한다.
double | tryAcquire() | 즉시 허가가 가능한 경우에만 true, 불가능하면 false 반환 (non-blocking 방식)
double | tryAcquire(long timeout, TimeUnit unit) | 정해진 시간안에 허가가 가능하면 true, 불가능하면 false (blocking)
  
* 해당 기능은 운영환경에서만 사용하고, application.yml에서 옵션값을 통해 필터링을 거침.
* 초당 5개의 요청을 허용
  * 초과 요청 시 429 Too Many Request Error 발생
* 관심사 분리를 위해 Rate Limiting은 Interceptor에서 처리
